### PR TITLE
Regel UFN.07

### DIFF
--- a/ruleset.ts
+++ b/ruleset.ts
@@ -17,6 +17,7 @@ const ruleInstances: Record<string, any> = {};
 const ruleTypes = [
   UfnRules.Ufn02,
   UfnRules.Ufn06,
+  UfnRules.Ufn07,
   UfnRules.Ufn09,
   SakRules.Sak09,
 ];

--- a/rulesets/UfnRules.ts
+++ b/rulesets/UfnRules.ts
@@ -27,6 +27,17 @@ export class Ufn06 implements RulesetInterface {
   }
   severity = DiagnosticSeverity.Error;
 }
+export class Ufn07 implements RulesetInterface {
+  given = "$.paths[*]~";
+  message = "{{property}} - URL:n SKALL använda tecken som är URL-säkra (tecknen A-Z, a-z, 0-9, \"-\", \".\", \"_\" samt \"~\", se vidare i RFC 3986).";
+  then = {
+    function: pattern,
+    functionOptions: {
+      match: "^[a-zA-Z0-9/\\\-\\\.\\\_\\\~]*$"
+    }
+  }
+  severity = DiagnosticSeverity.Error;
+}
 export class Ufn09 implements RulesetInterface {
   description = "Blanksteg ' ' och understreck '_' SKALL INTE användas i URL:er med undantag av parameter-delen.";
   given = "$.paths[*]~";
@@ -39,4 +50,4 @@ export class Ufn09 implements RulesetInterface {
   }
   severity = DiagnosticSeverity.Error;
 }
-export default { Ufn02, Ufn09 };
+export default { Ufn02, Ufn09, Ufn07 };

--- a/tests/ufn.test.ts
+++ b/tests/ufn.test.ts
@@ -54,6 +54,33 @@ testRule("Ufn06", [
       ],
     },
 ]);
+testRule("Ufn07", [
+  {
+      name: "giltigt testfall",
+      document: {
+        openapi: "3.1.0",
+        info: { version: "1.0" },
+        paths: { "/abcdefghijklmnopqrstuvxyzABCDEFGHIJKLMNOPQRSTUVXYZ-._~": {} },
+      },
+      errors: [],
+    },
+    {
+      name: "ogiltigt testfall med asterisk",
+      document: {
+        openapi: "3.1.0",
+        info: { version: "1.0" },
+        paths: { "/a-*-is-not-allowed": {} },
+      },
+      errors: [
+        {
+          message:
+            "/a-*-is-not-allowed - URL:n SKALL använda tecken som är URL-säkra (tecknen A-Z, a-z, 0-9, \"-\", \".\", \"_\" samt \"~\", se vidare i RFC 3986).",
+          path: ["paths", "/a-*-is-not-allowed"],
+          severity: DiagnosticSeverity.Error,
+        }
+      ],
+    },
+]);
 testRule("Ufn02", [
     {
         name: "giltigt testfall",


### PR DESCRIPTION
URL:n SKALL använda tecken som är URL-säkra (tecknen A-Z, a-z, 0-9, "-", ".", "_" samt "~", se vidare i RFC 3986).