### PR TITLE
Feature/231 Fix comandline help section

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,21 +2,71 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { execCLI } from './cli-mode.ts';
 import { startServer } from './api-mode.ts';
+import * as path from "node:path";
+import { getRuleModules } from "./util/ruleUtil.ts";
 
 async function main() {
-  const argv = await yargs(hideBin(process.argv))
+    const argv = await yargs(hideBin(process.argv)).version("1.2.0")
     .option('mode', {
       alias: 'm',
       describe: 'Körläget för applikationen (cli eller api)',
       choices: ['cli', 'api'],
       demandOption: true,
     })
-    .argv;
+    .option("file", {
+      alias: "f",
+      describe: "[cli mode] Path to the YAML file",
+      type: "string",
+      coerce: (file: string) => path.resolve(file), // convert to absolute path
+    })
+    .option("categories", {
+      alias: "c",
+      describe: `[cli mode] Regelkategorier separerade med kommatecken.\nAvailable categories:\r ${getRuleModules().join(",")}`,
+      type: "string",
+    })
+    .option("logError", {
+      alias: "l",
+      describe: 'Sökväg till fil med information för eventuell felloggningsinformation från RAP-LP. Om ej specificerad, så kommer felet att skrivas ut till stdout.',
+      type: 'string',
+    })
+    .option("append", {
+      alias: "a",
+      describe: "Utöka loginformationen i filen för felloggningsiformation. Utökda loginformation till befintlig fil för loggning av fel( om specificerad ).",
+      type: "boolean",
+      default: false,
+    })  
+    .option("logDiagnostic", {
+      alias: "d",
+      describe: 'Sökväg till fill för diagnostiseringsinformation från  RAP-LP. Om en specificerad , så kommer diagnostiseringsinformationen att skrivas ut till stdout.',
+      type: 'string',
+    })
+    .check(function (argv) {
+      if (!argv.mode) {
+        console.error('Missing required argument: mode ')
+      }
+      if (argv.mode === 'cli' && !argv.file) {
+          console.error('Missing required argument for cli mode: file')
+          return false;
+      }
+      else if(argv.mode === 'api') {
+        if (argv.file) {
+          console.error('Argument "file" is only applicable in CLI mode')
+          return false;
+        }
+
+        if(argv.categories) {
+          console.error(`Argument "categories" is only applicable in CLI mode`)
+          return false
+        }
+      }
+      return true;
+  })
+  .argv;
 
   const mode = argv.mode;
 
   if (mode === 'cli') {
-    await execCLI(); // Starta CLI-läget
+    await execCLI(argv); // Starta CLI-läget
   } else if (mode === 'api') {
     startServer(); // Starta API-läget
   }

--- a/src/cli-mode.ts
+++ b/src/cli-mode.ts
@@ -1,10 +1,8 @@
-import yargs from "yargs";
 import * as fs from "node:fs";
-import * as path from "node:path";
 import { join } from "path";
 import Parsers from "@stoplight/spectral-parsers";
 import { Document } from "@stoplight/spectral-core";
-import { importAndCreateRuleInstances, getRuleModules } from "./util/ruleUtil.ts"; // Import the helper function
+import { importAndCreateRuleInstances } from "./util/ruleUtil.ts"; // Import the helper function
 import util from 'util';
 import {RapLPCustomSpectral} from "./util/RapLPCustomSpectral.ts";
 import {DiagnosticReport, RapLPDiagnostic} from "./util/RapLPDiagnostic.ts";
@@ -19,43 +17,19 @@ declare var AggregateError: {
 const writeFileAsync = util.promisify(fs.writeFile);
 const appendFileAsync = util.promisify(fs.appendFile);
 
-export async function execCLI() {
+export type CliArgs = {
+  file?: string;
+  categories?: string;
+  logError?: string;
+  append: boolean;
+  logDiagnostic?: string;
+}
+
+export async function execCLI<T extends CliArgs>(argv: T) {
     try {
         // Parse command-line arguments using yargs
-        const argv = await yargs(process.argv.slice(2)).version("1.2.0")
-          .option("file", {
-            alias: "f",
-            describe: "Path to the YAML file",
-            demandOption: true,
-            type: "string",
-            coerce: (file: string) => path.resolve(file), // convert to absolute path
-          })
-          .option("categories", {
-            alias: "c",
-            describe: `Regelkategorier separerade med kommatecken.\nAvailable categories:\r ${getRuleModules().join(",")}`,
-            type: "string",
-          })
-          .option("logError", {
-            alias: "l",
-            describe: 'Sökväg till fil med information för eventuell felloggningsinformation från RAP-LP. Om ej specificerad, så kommer felet att skrivas ut till stdout.',
-            type: 'string',
-          })
-          .option("append", {
-            alias: "a",
-            describe: "Utöka loginformationen i filen för felloggningsiformation. Utökda loginformation till befintlig fil för loggning av fel( om specificerad ).",
-            type: "boolean",
-            default: false,
-          })  
-          .option("logDiagnostic", {
-            alias: "d",
-            describe: 'Sökväg till fill för diagnostiseringsinformation från  RAP-LP. Om en specificerad , så kommer diagnostiseringsinformationen att skrivas ut till stdout.',
-            type: 'string',
-          }).argv;
+        
 
-         /* if (argv.help || argv.h) {
-            yargs(argv).showHelp();
-          }*/
-        // Extract arguments from yargs
         const apiSpecFileName = (argv.file as string) || "";
         const ruleCategories = argv.categories ? (argv.categories as string).split(",") : undefined;
         const logErrorFilePath = argv.logError as string | undefined;


### PR DESCRIPTION
# Pull Request Description

Help section would only show the mode argument. 
Moved all argument handling to top level, added additional checks to catch mix of API and CLI mode arguments.

Fixes #231 

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
