### PR TITLE
Chore/19 schemalagg renovate automerge och hoj minimalreleaseage

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
     "mergeConfidence:all-badges"
   ],
   "commitMessageLowerCase": "auto",
-  "minimumReleaseAge": "4 days",
+  "minimumReleaseAge": "7 days",
   "labels": ["dependencies"],
   "vulnerabilityAlerts": {
     "labels": ["security", "dependencies"]

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,8 @@
   "vulnerabilityAlerts": {
     "labels": ["security", "dependencies"]
   },
+  "timezone": "Europe/Stockholm",
+  "automergeSchedule": ["0 9-21 * * 6"],
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
Update renovate.json to increase minimumReleaseAge to 7 days, set timezone to Stockholm and automergeSchedule to hourly on Saturdays between 9 and 21.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
