### PR TITLE
chore(renovate): update automerge for patches to only run on sat

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,8 +24,14 @@
     "labels": ["security", "dependencies"]
   },
   "timezone": "Europe/Stockholm",
+  "platformAutomerge": false,
   "automergeSchedule": ["0 9-21 * * 6"],
   "packageRules": [
+    {
+      "description": "Automerge endast patch",
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    },
     {
       "matchManagers": ["github-actions"],
       "addLabels": ["actions"],


### PR DESCRIPTION
# Update automerge for patches to only run on saturdays

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
