### PR TITLE
ci: use reuseable-ci v2, dev npm support

### DIFF
--- a/.github/artifacts.yml
+++ b/.github/artifacts.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 diggsweden/rest-api-profil-lint-processor
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Artifacts Configuration for rest-api-profil-lint-processor
+# NPM CLI application with container
+# Package tarballs will be attached to GitHub Release as assets
+
+artifacts:
+  - name: raplp
+    project-type: npm
+    working-directory: .
+    build-type: application
+    config:
+      node-version: 22
+
+# Container builds from source (no artifact dependency)
+# Containerfile copies source code and runs npm install
+containers:
+  - name: raplp
+    container-file: Containerfile
+    context: .
+    platforms: linux/amd64,linux/arm64
+    registry: ghcr.io

--- a/.github/workflows/openssfscorecard.yml
+++ b/.github/workflows/openssfscorecard.yml
@@ -6,9 +6,6 @@
 name: OpenSSF Scorecard analysis
 
 on:
-  push:
-    branches:
-      - main
   schedule:
     # Weekly on Thursdays at 01:30 UTC
     - cron: "30 1 * * 4"
@@ -22,4 +19,4 @@ jobs:
       contents: read
       security-events: write
       id-token: write
-    uses: diggsweden/reusable-ci/.github/workflows/security-openssf-scorecard.yml@v1
+    uses: diggsweden/reusable-ci/.github/workflows/security-openssf-scorecard.yml@v2

--- a/.github/workflows/pullrequest-workflow.yml
+++ b/.github/workflows/pullrequest-workflow.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   pr-checks:
-    uses: diggsweden/reusable-ci/.github/workflows/pullrequest-orchestrator.yml@v1
+    uses: diggsweden/reusable-ci/.github/workflows/pullrequest-orchestrator.yml@v2
     secrets: inherit  # Pass org-level secrets (NPM token if private packages)
     permissions:
       contents: read         # Clone repository and read source code

--- a/.github/workflows/release-dev-workflow.yml
+++ b/.github/workflows/release-dev-workflow.yml
@@ -4,33 +4,35 @@
 
 # Release Workflow Dev
 # 
-# This workflow triggers the dev release orchestrator for development and feature branches.
-# It creates dev-tagged artifacts and container images for testing.
+# Triggers dev builds for testing on development branches.
+# Creates:
+# - Dev container image (ghcr.io)
+# - Dev NPM package (GitHub Packages)
 #
 # Triggers:
 # - Push to dev/* or feat/* branches  
 # - Manual workflow dispatch
 #
 # Created artifacts:
-# - Maven/NPM packages with -dev versions (e.g., 1.2.4-dev.1)
-# - Container images with dev tags
-# - See release summary for full details
+# - NPM package: @diggsweden/rest-api-profil-lint-processor@0.5.9-dev-feat-name-abc1234
+# - Container image: ghcr.io/diggsweden/rest-api-profil-lint-processor:0.5.9-dev-feat-name-abc1234
+# - Tagged with 'dev' (not 'latest')
 
 name: Release Workflow Dev
 
 on:
-  push:
-    branches:
-      - 'dev/**'
-      - 'feat/**'
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   dev-release:
     permissions:
-      contents: write         # Read code and create version bump commits
-      packages: write         # Push dev images to ghcr.io
-    uses: diggsweden/reusable-ci/.github/workflows/release-dev-orchestrator.yml@v1
+      contents: read
+      packages: write
+    uses: diggsweden/reusable-ci/.github/workflows/release-dev-orchestrator.yml@v2
     with:
-      projectType: npm
+      project-type: npm
+      package-scope: "@diggsweden"
     secrets: inherit

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -2,9 +2,8 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-# Description:
-# This workflow handles automated releases using the unified release system
-# from diggsweden/.github for NPM packages.
+# Release Workflow for rest-api-profil-lint-processor
+# Uses the unified release orchestrator for NPM packages
 ---
 name: Release
 
@@ -25,41 +24,16 @@ permissions:
 
 jobs:
   release:
-    name: Release
-    if: startsWith(github.ref, 'refs/tags/v')  # Only run for version tags
+    uses: diggsweden/reusable-ci/.github/workflows/release-orchestrator.yml@v2
     permissions:
-      contents: write  # Create GitHub releases, push changelog commits
-      packages: write  # Publish NPM package to GitHub registry, push to ghcr.io
-      id-token: write  # Generate OIDC token for package provenance and SLSA
-      actions: read    # Required for SLSA provenance generation
+      contents: write         # Create GitHub releases, push changelog commits
+      packages: write         # Publish to GitHub Packages
+      id-token: write         # Generate OIDC token for SLSA provenance
+      attestations: write     # Attach SBOM attestations
       security-events: write  # Upload container vulnerability scan results
-      attestations: write     # Attach SBOM attestation to container images
-      issues: write           # Close issues and add release comments
-    uses: diggsweden/reusable-ci/.github/workflows/release-orchestrator.yml@v1
+      actions: read           # Required for SLSA provenance
+    secrets: inherit
     with:
-      # Project configuration
-      projectType: npm  # Build system (reads version from package.json)
-      branch: main      # Base branch for changelog generation
-      
-      # Artifact publisher configuration
-      artifactPublisher: npm-app-github  # Publish to GitHub NPM registry
-      # Uses default Node version (22.x)
-      
-      # Container builder configuration
-      containerBuilder: containerimage-ghcr  # Build Docker image and push to ghcr.io
-      # Defaults: linux/amd64, SLSA provenance, SBOM generation enabled
-      
-      # NPM specific - files to commit when version changes
-      file_pattern: "CHANGELOG.md package.json package-lock.json"
-      
-      # Changelog configuration
-      changelogCreator: git-cliff  # Generate from conventional commits
-      # Uses default changelog format
-      
-      # Release publisher configuration
-      releasePublisher: github-cli         # GitHub CLI better for NPM than JReleaser
-      release.generatesbom: true           # Include SBOM in release assets
-      release.signartifacts: true          # GPG sign all release artifacts
-      
-      # Release type auto-detected from tag (v1.0.0 = stable, v1.0.0-beta = prerelease)
-    secrets: inherit  # Use org-level NPM_TOKEN and GPG keys if available
+      artifacts-config: .github/artifacts.yml
+      file-pattern: "CHANGELOG.md package.json package-lock.json"
+      release-publisher: github-cli


### PR DESCRIPTION
Use reuseable-ci v2. (Lots of changes, too much to mention). 
One thing It adds is npm dev build support, adapted from @brorlarsnicklas 


## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
