### PR TITLE
fix: publish npm package to gh

### DIFF
--- a/.github/artifacts.yml
+++ b/.github/artifacts.yml
@@ -11,6 +11,8 @@ artifacts:
     project-type: npm
     working-directory: .
     build-type: application
+    publish-to:
+      - github-packages
     config:
       node-version: 22
 

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -21,6 +21,6 @@ jobs:
       contents: read
       security-events: write
       id-token: write
-    uses: diggsweden/reusable-ci/.github/workflows/security-openssf-scorecard.yml@1a7dcd9c5257495ebf141e4e4b4bac438a8aae56 # v2.0.0
+    uses: diggsweden/reusable-ci/.github/workflows/security-openssf-scorecard.yml@1baa694d94c5324f9b5abec6d22542d2c395169d # v2.2.3
     with:
       publish-results: true

--- a/.github/workflows/pullrequest-workflow.yml
+++ b/.github/workflows/pullrequest-workflow.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   pr-checks:
-    uses: diggsweden/reusable-ci/.github/workflows/pullrequest-orchestrator.yml@1a7dcd9c5257495ebf141e4e4b4bac438a8aae56 # v2.0.0
+    uses: diggsweden/reusable-ci/.github/workflows/pullrequest-orchestrator.yml@1baa694d94c5324f9b5abec6d22542d2c395169d # v2.2.3
     secrets: inherit # Pass org-level secrets (NPM token if private packages)
     permissions:
       contents: read # Clone repository and read source code

--- a/.github/workflows/release-dev-workflow.yml
+++ b/.github/workflows/release-dev-workflow.yml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: diggsweden/reusable-ci/.github/workflows/release-dev-orchestrator.yml@1a7dcd9c5257495ebf141e4e4b4bac438a8aae56 # v2.0.0
+    uses: diggsweden/reusable-ci/.github/workflows/release-dev-orchestrator.yml@1baa694d94c5324f9b5abec6d22542d2c395169d # v2.2.3
     with:
       project-type: npm
       package-scope: '@diggsweden'

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   release:
-    uses: diggsweden/reusable-ci/.github/workflows/release-orchestrator.yml@1a7dcd9c5257495ebf141e4e4b4bac438a8aae56 # v2.0.0
+    uses: diggsweden/reusable-ci/.github/workflows/release-orchestrator.yml@1baa694d94c5324f9b5abec6d22542d2c395169d # v2.2.3
     permissions:
       contents: write # Create GitHub releases, push changelog commits
       packages: write # Publish to GitHub Packages


### PR DESCRIPTION
Add publish-to in artifacts yml
Uses (bugfixed) reuseable ci v2.2.3

This was tested "for real" in the throwaway project Rest-api-profill...ci" with success.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
